### PR TITLE
Fix lifeline tracking

### DIFF
--- a/game.js
+++ b/game.js
@@ -24,7 +24,8 @@ class MillionaireGame {
         this.usedLifelines = {
             fiftyFifty: false,
             phoneFriend: false,
-            askAudience: false
+            askAudience: false,
+            lastQuestionUsed: -1
         };
         
         this.timer = null;
@@ -121,7 +122,8 @@ class MillionaireGame {
         this.usedLifelines = {
             fiftyFifty: false,
             phoneFriend: false,
-            askAudience: false
+            askAudience: false,
+            lastQuestionUsed: -1
         };
         
         this.timeLeft = 60;
@@ -271,8 +273,11 @@ class MillionaireGame {
 
     checkAnswer(selectedAnswer) {
         const thinkingTime = (Date.now() - this.thinkingStartTime) / 1000;
-        const usedLifelinesOnCurrentQuestion = Object.values(this.usedLifelines).some(used => used) && 
-            this.usedLifelines.lastQuestionUsed === this.currentQuestion;
+        const lifelineUsed = this.usedLifelines.fiftyFifty ||
+                             this.usedLifelines.phoneFriend ||
+                             this.usedLifelines.askAudience;
+        const usedLifelinesOnCurrentQuestion =
+            lifelineUsed && this.usedLifelines.lastQuestionUsed === this.currentQuestion;
 
         if (thinkingTime > 25 || usedLifelinesOnCurrentQuestion) {
             this.selectedAnswer = selectedAnswer;


### PR DESCRIPTION
## Summary
- track when lifelines are used with `lastQuestionUsed`
- check only boolean lifeline flags when confirming answers

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_b_68408a6a0830832c96381b78898b8738