### PR TITLE
Secure bot token via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,12 @@ npm test
 ```
 
 The test environment uses JSDOM to simulate the game DOM and verify behaviours of `MillionaireGame`.
+
+## Bot configuration
+
+The Telegram bot expects its token to be supplied via the `BOT_TOKEN` environment
+variable. Start the bot with:
+
+```bash
+BOT_TOKEN=your-telegram-token node bot.js
+```

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,8 @@
 const TelegramBot = require('node-telegram-bot-api');
-const token = '8139802825:AAH3ZzyGN8WS3hlWez7u0GzrbLlyTH8eBKI';
+const token = process.env.BOT_TOKEN;
+if (!token) {
+    throw new Error('BOT_TOKEN environment variable not set');
+}
 const webAppUrl = 'https://github.com/alvec7/telegram-game'; // Новый URL
 
 const bot = new TelegramBot(token, {polling: true});


### PR DESCRIPTION
## Summary
- remove token literal in `bot.js`
- load token from `BOT_TOKEN` env var
- document bot token variable in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684092a52190832ca46aef2f27394f6e