### PR TITLE
Add mobile CSS tweaks for small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -262,6 +262,41 @@ body {
     }
 }
 
+/* Extra small screens */
+@media (max-width: 480px) {
+    .header h1 {
+        font-size: 2em;
+        padding: 15px;
+    }
+
+    .question {
+        font-size: 1em;
+        padding: 15px 20px;
+    }
+
+    .answer {
+        padding: 10px 15px;
+        font-size: 1em;
+    }
+
+    .lifelines {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 10px;
+    }
+
+    .lifelines button {
+        width: 100%;
+        padding: 8px 15px;
+        font-size: 0.9em;
+    }
+
+    .start-button {
+        padding: 20px 40px;
+        font-size: 1.4em;
+    }
+}
+
 .timer {
     position: absolute;
     top: -40px;


### PR DESCRIPTION
## Summary
- add an `@media (max-width: 480px)` section to reduce font and padding
- stack lifeline buttons vertically on small screens and stretch them to full width

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684092d1e9c8832c8c6b31b5c90f19dc