### PR TITLE
Add mobile tooltip support

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,15 @@
             </div>
             
             <div class="lifelines">
-                <button id="fifty-fifty"><i class="fas fa-percent"></i>50/50</button>
-                <button id="phone-friend"><i class="fas fa-phone"></i>Звонок другу</button>
-                <button id="ask-audience"><i class="fas fa-user-friends"></i>Помощь зала</button>
+                <div class="lifeline" data-tooltip="Убрать два неверных ответа">
+                    <button id="fifty-fifty" title="Убрать два неверных ответа"><i class="fas fa-percent"></i>50/50</button>
+                </div>
+                <div class="lifeline" data-tooltip="Позвонить другу за подсказкой">
+                    <button id="phone-friend" title="Позвонить другу за подсказкой"><i class="fas fa-phone"></i>Звонок другу</button>
+                </div>
+                <div class="lifeline" data-tooltip="Спросить мнение зала">
+                    <button id="ask-audience" title="Спросить мнение зала"><i class="fas fa-user-friends"></i>Помощь зала</button>
+                </div>
             </div>
         </div>
         <div class="start-button-container" id="start-button-container">

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,36 @@ body {
     cursor: not-allowed;
 }
 
+/* Tooltip for lifeline buttons */
+.lifeline {
+    position: relative;
+    display: inline-flex;
+}
+
+.lifeline::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 5px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.8);
+    color: #fff;
+    padding: 5px 8px;
+    border-radius: 4px;
+    font-size: 0.8em;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease-in-out;
+    z-index: 10;
+}
+
+.lifeline:hover::after,
+.lifeline:focus-within::after,
+.lifeline:active::after {
+    opacity: 1;
+}
+
 .host-message {
     width: 100%;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- add `title` attributes and wrappers for lifeline buttons
- show tooltip text on hover, focus or long press via CSS

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68409b6a5e24832cbb301651711d3ae6