### PR TITLE
Add modal fade animations

### DIFF
--- a/game.js
+++ b/game.js
@@ -65,8 +65,10 @@ class MillionaireGame {
                 if (modal) {
                     if (modal.id === 'confirmation-modal') {
                         this.hideConfirmationModal();
-                    } else {
-                        modal.style.display = 'none';
+                    } else if (modal.id === 'winner-modal') {
+                        this.hideWinnerModal();
+                    } else if (modal.id === 'consolation-modal') {
+                        this.hideConsolationModal();
                     }
                 }
             });
@@ -111,8 +113,7 @@ class MillionaireGame {
         
         // Добавляем обработчик для кнопки "Сыграть снова"
         document.querySelector('.play-again').addEventListener('click', () => {
-            this.consolationModal.style.display = 'none';
-            this.resetGame();
+            this.hideConsolationModal(() => this.resetGame());
         });
     }
 
@@ -378,10 +379,35 @@ class MillionaireGame {
 
     showWinnerModal() {
         this.winnerModal.style.display = 'flex';
+        this.winnerModal.classList.remove('fade-out');
+        void this.winnerModal.offsetWidth;
+        this.winnerModal.classList.add('fade-in');
     }
 
     showConsolationModal() {
         this.consolationModal.style.display = 'flex';
+        this.consolationModal.classList.remove('fade-out');
+        void this.consolationModal.offsetWidth;
+        this.consolationModal.classList.add('fade-in');
+    }
+
+    hideWinnerModal() {
+        this.winnerModal.classList.remove('fade-in');
+        this.winnerModal.classList.add('fade-out');
+        this.winnerModal.addEventListener('animationend', () => {
+            this.winnerModal.style.display = 'none';
+            this.winnerModal.classList.remove('fade-out');
+        }, { once: true });
+    }
+
+    hideConsolationModal(callback) {
+        this.consolationModal.classList.remove('fade-in');
+        this.consolationModal.classList.add('fade-out');
+        this.consolationModal.addEventListener('animationend', () => {
+            this.consolationModal.style.display = 'none';
+            this.consolationModal.classList.remove('fade-out');
+            if (callback) callback();
+        }, { once: true });
     }
 
     winGame() {

--- a/styles.css
+++ b/styles.css
@@ -431,6 +431,24 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}
+
+.fade-in {
+    animation: fadeIn 0.5s forwards;
+}
+
+.fade-out {
+    animation: fadeOut 0.5s forwards;
+}
+
 .prize-modal {
     display: none;
     position: fixed;


### PR DESCRIPTION
## Summary
- add `fadeIn` and `fadeOut` CSS animations with helper classes
- use fade classes when showing and hiding prize modals
- hook close buttons and "play again" to animated close

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68409b7d1a54832cb52f01b843b29f37