### PR TITLE
Add rules modal shown before game

### DIFF
--- a/game.js
+++ b/game.js
@@ -52,6 +52,8 @@ class MillionaireGame {
         
         this.winnerModal = document.getElementById('winner-modal');
         this.consolationModal = document.getElementById('consolation-modal');
+        this.rulesModal = document.getElementById('rules-modal');
+        this.rulesContinueButton = document.getElementById('rules-continue');
         
         this.initializeElements();
         this.initializeEventListeners();
@@ -61,10 +63,12 @@ class MillionaireGame {
         // Находим все кнопки закрытия
         document.querySelectorAll('.close-button').forEach(button => {
             button.addEventListener('click', (e) => {
-                const modal = e.target.closest('.confirmation-modal, .prize-modal');
+                const modal = e.target.closest('.confirmation-modal, .prize-modal, .rules-modal');
                 if (modal) {
                     if (modal.id === 'confirmation-modal') {
                         this.hideConfirmationModal();
+                    } else if (modal.id === 'rules-modal') {
+                        this.hideRulesModal();
                     } else {
                         modal.style.display = 'none';
                     }
@@ -108,6 +112,10 @@ class MillionaireGame {
         this.confirmNoButton.addEventListener('click', () => this.handleConfirmation(false));
 
         this.startButton.addEventListener('click', () => this.startFirstQuestion());
+
+        if (this.rulesContinueButton) {
+            this.rulesContinueButton.addEventListener('click', () => this.hideRulesModal());
+        }
         
         // Добавляем обработчик для кнопки "Сыграть снова"
         document.querySelector('.play-again').addEventListener('click', () => {
@@ -154,12 +162,6 @@ class MillionaireGame {
     }
 
     startGame() {
-        const introMessages = [
-            "Приветствуем вас на игре «Кто хочет стать миллионером»! Вам предстоит проверить свои знания о морском деле и побороться за миллион.",
-            "Для ответа на каждый вопрос у вас будет ровно минута. Следите за временем — секундомер справа от вас.",
-            "Наш спонсор – маркетплейс яхтенных туров ImSkipper – желает вам семь футов под килем! Отдать швартовы!"
-        ];
-
         this.questionElement.style.visibility = 'hidden';
         Object.values(this.answerButtons).forEach(button => {
             button.style.visibility = 'hidden';
@@ -168,21 +170,7 @@ class MillionaireGame {
         this.startButtonContainer.style.display = 'none';
         this.lifelinesContainer.style.display = 'none';
 
-        this.showHostMessage(introMessages[0]);
-        
-        setTimeout(() => {
-            this.showHostMessage(introMessages[1]);
-            
-            setTimeout(() => {
-                this.showHostMessage(introMessages[2]);
-                
-                setTimeout(() => {
-                    this.startButtonContainer.style.display = 'block';
-                }, 5000);
-                
-            }, 5000);
-            
-        }, 5000);
+        this.showRulesModal();
     }
 
     startFirstQuestion() {
@@ -382,6 +370,19 @@ class MillionaireGame {
 
     showConsolationModal() {
         this.consolationModal.style.display = 'flex';
+    }
+
+    showRulesModal() {
+        if (this.rulesModal) {
+            this.rulesModal.style.display = 'flex';
+        }
+    }
+
+    hideRulesModal() {
+        if (this.rulesModal) {
+            this.rulesModal.style.display = 'none';
+        }
+        this.startButtonContainer.style.display = 'block';
     }
 
     winGame() {

--- a/index.html
+++ b/index.html
@@ -42,6 +42,18 @@
             <button id="start-button" class="start-button">Начать игру</button>
         </div>
     </div>
+    <div class="rules-modal" id="rules-modal">
+        <div class="rules-content">
+            <button class="close-button">×</button>
+            <h2>Правила игры</h2>
+            <div class="rules-text">
+                <p>Приветствуем вас на игре «Кто хочет стать миллионером»! Вам предстоит проверить свои знания о морском деле и побороться за миллион.</p>
+                <p>Для ответа на каждый вопрос у вас будет ровно минута. Следите за временем — секундомер справа от вас.</p>
+                <p>Наш спонсор – маркетплейс яхтенных туров ImSkipper – желает вам семь футов под килем! Отдать швартовы!</p>
+            </div>
+            <button id="rules-continue" class="prize-button">Продолжить</button>
+        </div>
+    </div>
     <div class="confirmation-modal" id="confirmation-modal">
         <div class="modal-content">
             <button class="close-button">×</button>

--- a/styles.css
+++ b/styles.css
@@ -431,6 +431,42 @@ body {
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+.rules-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);
+    z-index: 1000;
+    justify-content: center;
+    align-items: center;
+}
+
+.rules-content {
+    background: var(--primary-color);
+    padding: 30px;
+    border-radius: 15px;
+    border: 2px solid var(--timer-border);
+    max-width: 600px;
+    width: 90%;
+    max-height: 70vh;
+    overflow-y: auto;
+    position: relative;
+    text-align: left;
+    line-height: 1.5;
+}
+
+.rules-content h2 {
+    text-align: center;
+    margin-top: 0;
+}
+
+.rules-text {
+    margin-bottom: 20px;
+}
+
 .prize-modal {
     display: none;
     position: fixed;


### PR DESCRIPTION
## Summary
- create rules modal with intro text and Continue button
- style rules modal and content
- show rules modal instead of timed intro sequence
- add JS handlers to open and close the rules modal

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68409b87e2ec832c9e08bb6e150a7528